### PR TITLE
chaining

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-common/string-map",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "String Map",
   "main": "dist/index.js",
   "scripts": {
@@ -36,22 +36,24 @@
     "statements": 100,
     "functions": 100,
     "branches": 100,
-    "exclude": [ "dist/test.js" ]
+    "exclude": [
+      "dist/test.js"
+    ]
   },
   "homepage": "https://github.com/ts-common/string-map#readme",
   "devDependencies": {
     "@types/chai": "^4.1.7",
-    "@types/mocha": "^5.2.5",
+    "@types/mocha": "^5.2.6",
     "chai": "^4.2.0",
-    "mocha": "^5.2.0",
+    "mocha": "^6.0.2",
     "mocha-junit-reporter": "^1.18.0",
-    "nyc": "^13.2.0",
-    "tslint": "^5.12.1",
-    "tslint-immutable": "^5.1.2",
+    "nyc": "^13.3.0",
+    "tslint": "^5.13.1",
+    "tslint-immutable": "^5.3.3",
     "typescript": "~3.2.4"
   },
   "dependencies": {
-    "@ts-common/iterator": "^0.1.3",
+    "@ts-common/iterator": "^0.1.4",
     "@ts-common/tuple": "^0.0.6"
   }
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -14,19 +14,19 @@ describe("groupBy", () => {
 
 describe("values", () => {
     it("array", () => {
-        const result = Array.from(_.values({ 1: 2, 2: 2, 3: 3 }))
+        const result = _.values({ 1: 2, 2: 2, 3: 3 }).toArray()
         assert.deepEqual([2, 2, 3], result)
     })
     it("array with undefined", () => {
         const x: { [name: string]: number|undefined } = { 1: 2, 2: 4, t: undefined }
-        const result: ReadonlyArray<number> = Array.from(_.values(x))
+        const result: ReadonlyArray<number> = _.values(x).toArray()
         assert.deepEqual([2, 4], result)
     })
 })
 
 describe("names", () => {
     it("array", () => {
-        const result = Array.from(_.keys({ 1: 2, 2: 2, 3: 3, 4: undefined }))
+        const result = _.keys({ 1: 2, 2: 2, 3: 3, 4: undefined }).toArray()
         assert.deepEqual(["1", "2", "3"], result)
     })
 })
@@ -42,7 +42,7 @@ describe("entry", () => {
 
 describe("allKeys", () => {
     it("undefined", () => {
-        const x = Array.from(_.allKeys(undefined))
+        const x = _.allKeys(undefined).toArray()
         assert.strictEqual(x.length, 0)
     })
 })
@@ -50,16 +50,16 @@ describe("allKeys", () => {
 describe("entries", () => {
     it("array", () => {
         const x: { [name: string]: number } = { 1: 2, 2: 2, 3: 3 }
-        const result = Array.from(_.entries(x))
+        const result = _.entries(x).toArray()
         assert.deepEqual([_.entry("1", 2), _.entry("2", 2), _.entry("3", 3)], result)
     })
     it("array with undefined", () => {
         const x: { [name: string]: number|undefined } = { 1: 2, 2: 2, t: undefined }
-        const result = Array.from(_.entries(x))
+        const result = _.entries(x).toArray()
         assert.deepEqual([_.entry("1", 2), _.entry("2", 2)], result)
     })
     it("undefined", () => {
-        const x = Array.from(_.entries(undefined))
+        const x = _.entries(undefined).toArray()
         assert.strictEqual(x.length, 0)
     })
 })


### PR DESCRIPTION
The changes will allow to chain functions, for example
```ts
string_map.entries({ a: "A", b: "B" }).toArray()
```
instead of
```ts
Array.from(string_map.entries({ a: "A", b: "B" }))
```

https://github.com/ts-common/iterator/pull/17